### PR TITLE
Fix motion tracking on iOS

### DIFF
--- a/ios/PanoramaView.m
+++ b/ios/PanoramaView.m
@@ -91,8 +91,8 @@
 
 -(void)setEnableTouchTracking:(BOOL)enableTouchTracking
 {
-    if (enableTouchTracking) {
-        _panoView.controlMethod = CTPanoramaControlMethodTouch;
+    if (!enableTouchTracking) {
+        _panoView.controlMethod = CTPanoramaControlMethodMotion;
     }
 }
 

--- a/ios/PanoramaView.m
+++ b/ios/PanoramaView.m
@@ -91,7 +91,9 @@
 
 -(void)setEnableTouchTracking:(BOOL)enableTouchTracking
 {
-    if (!enableTouchTracking) {
+    if (enableTouchTracking) {
+        _panoView.controlMethod = CTPanoramaControlMethodTouch;
+    } else {
         _panoView.controlMethod = CTPanoramaControlMethodMotion;
     }
 }


### PR DESCRIPTION
CTPanoramaView default control method is touch. This change reflects that to allow this library to support motion controls on iOS.