### PR TITLE
Update readme.md with RN >= 0.65.0 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ React Native Panorama viewer for Android and iOS.
 
 `$ cd ios && pod install`
 
+If you're using RN >= 0.65.0 and you're obtaining errors like "Could not find com.google.vr:..." while compiling, you need to add back `jcenter()` in your `android/build.gradle` repositories:
+```
+allprojects {
+    repositories {
+        // ...
+        jcenter() // <- ADD THIS!
+    }
+}
+```
+
 ## Troubleshooting iOS
 
 If you're app doesn't compile due to Swift or linker errors. Follow these steps.


### PR DESCRIPTION
Resolves #72


In React Native 0.65.0 they removed jcenter() from the repositories in the android/build.gradle (proof: https://react-native-community.github.io/upgrade-helper/?from=0.64.2&to=0.65.0).

They removed it because jcenter is no more active, but it's reachable as a read-only repository (proof: https://developer.android.com/studio/build/jcenter-migration) so you can add it back if you need it, like in this case since com.google.vr is deprecated and ufficially it won't be uploaded to other active repositories.